### PR TITLE
Add CONTRIBUTING.md with CI/CD-specific guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to circleci-orb-deterministic-zip
+I love your input! I want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## I develop with Github
+I use github to host code, to track issues and feature requests, as well as accept pull requests.
+
+## I Use [CircleCI](https://circleci.com/product/), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (I use [CircleCI](https://circleci.com/product/)). I actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the tests pass.
+5. Make sure your code and commit lints.
+6. Issue that pull request!
+
+## Any contributions you make will be under the MIT License
+In short, when you submit code changes, your submissions are understood to be under the same [MIT License](https://github.com/timo-reymann/timo-reymann/circleci-orb-deterministic-zip/blob/main/LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Report bugs using Github's issues
+I use GitHub issues to track public bugs. Report a bug by opening a new issue, it's that easy!
+
+## Write bug reports with detail, background, and sample code
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+    - Be specific!
+    - Give sample code if you can.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People *love* thorough bug reports. I'm not even kidding.
+
+To make your life easier there is also a handy template available so feel free to use it.
+
+> ATTENTION: If you DONT provide steps to reproduce the ticket will be closed WITHOUT FURTHER NOTICE!
+
+## License
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+
+## AI-Generated Contributions Policy
+
+I accept AI-generated contributions to my projects, but with the following important conditions:
+
+1. **Understanding Requirement**: The human user authoring the change must have a clear conceptual understanding of what the code does and how it works.
+
+2. **Ownership Awareness**: The human contributor must understand that they own the intellectual property rights to the result, not the AI agent or tool that assisted them.
+
+3. **Explicit Attribution**: The human contributor must clearly state their understanding and compliance with the above conditions through one of these methods:
+   - Using "Co-Authored-By" attribution in the commit message
+   - Explicitly mentioning in the GitHub pull request description that AI assistance was used and that they understand and take responsibility for the changes
+
+4. **Right to Decline**: If these conditions are not clearly met in the contribution, I reserve the right to decline the pull request without further explanation.
+
+5. **Quality Standards**: All contributions, whether AI-assisted or not, must meet the same quality standards and will be evaluated on their technical merit.
+
+By contributing to this project, you agree to these terms and acknowledge that you are responsible for the code you submit, regardless of how it was generated.


### PR DESCRIPTION

            This PR adds a CONTRIBUTING.md file with guidelines specific to this project's CI/CD setup.
            
            The guidelines include:
            - General contribution rules
            - CI/CD-specific instructions
            - License information
            
            Template used: circleci
            
✅ Added CONTRIBUTING.md with circleci template